### PR TITLE
Update default instance type to micro

### DIFF
--- a/vars.tf
+++ b/vars.tf
@@ -87,7 +87,7 @@ variable "kubernetes_node_pools" {
   description = "Node pool(s) to create for this Kubernetes cluster"
   type        = list(map(string))
   default = [{
-    node_type   = "play2_nano"
+    node_type   = "play2_micro"
     autoscaling = true
     autohealing = true
     size        = 1


### PR DESCRIPTION
Upgrading from `PLAY2-NANO` to `PLAY2-MICRO` as the default instance type.

<img width="793" alt="Screenshot 2023-08-19 at 15 00 44" src="https://github.com/mastodon-site/scaleway-kubernetes/assets/6753180/1f3c37af-3d2f-40d2-a35d-35bed8dd4ecc">
