### PR TITLE
fix some issues on starting a fresh cluster

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -1,5 +1,6 @@
 resource "scaleway_k8s_cluster" "cluster" {
   name                        = var.kubernetes_cluster_name
+  region                      = var.scaleway_region
   type                        = "kapsule"
   version                     = var.kubernetes_cluster_version
   cni                         = "cilium"

--- a/external-secrets.tf
+++ b/external-secrets.tf
@@ -29,37 +29,4 @@ resource "kubernetes_secret" "scaleway_secret_manager_credentials" {
   }
 }
 
-resource "kubernetes_manifest" "secret_manager_store" {
-  manifest = {
-    "apiVersion" = "external-secrets.io/v1"
-    "kind"       = "ClusterSecretStore"
-    "metadata" = {
-      "name" = "secret-manager"
-    }
-    "spec" = {
-      "provider" = {
-        "scaleway" = {
-          "region"    = var.scaleway_region
-          "projectId" = var.scaleway_project_id
-
-          "accessKey" = {
-            "secretRef" = {
-              "name"      = "scaleway-secret-manager-credentials"
-              "namespace" = "kube-system"
-              "key"       = "access-key"
-            }
-          }
-
-          "secretKey" = {
-            "secretRef" = {
-              "name"      = "scaleway-secret-manager-credentials"
-              "namespace" = "kube-system"
-              "key"       = "secret-access-key"
-            }
-          }
-        }
-      }
-    }
-  }
-  depends_on = [kubernetes_secret.scaleway_secret_manager_credentials, scaleway_k8s_cluster.cluster]
-}
+# ClusterSecretStore is managed by Flux in kubernetes-state/kubernetes-0/platform/external-secrets.yaml

--- a/flux.tf
+++ b/flux.tf
@@ -5,6 +5,7 @@ resource "helm_release" "flux_operator" {
   chart            = "flux-operator"
   version          = "0.43.0"
   create_namespace = true
+  depends_on       = [scaleway_k8s_pool.pools]
 }
 
 resource "kubernetes_secret" "flux_git_credentials" {

--- a/lb.tf
+++ b/lb.tf
@@ -8,10 +8,11 @@ resource "scaleway_lb_ip" "ingress_ipv6" {
 }
 
 resource "scaleway_lb" "ingress" {
-  count  = var.create_lb ? 1 : 0
-  ip_ids = [scaleway_lb_ip.ingress_ipv4[0].id, scaleway_lb_ip.ingress_ipv6[0].id]
-  name   = "${var.kubernetes_cluster_name}-ingress"
-  type   = var.lb_type
+  count                   = var.create_lb ? 1 : 0
+  ip_ids                  = [scaleway_lb_ip.ingress_ipv4[0].id, scaleway_lb_ip.ingress_ipv6[0].id]
+  name                    = "${var.kubernetes_cluster_name}-ingress"
+  ssl_compatibility_level = "ssl_compatibility_level_modern"
+  type                    = var.lb_type
 
   private_network {
     private_network_id = var.private_network_id

--- a/values/components.yaml
+++ b/values/components.yaml
@@ -29,3 +29,10 @@ instance:
             value:
               - key: "CriticalAddonsOnly"
                 operator: "Exists"
+      - target:
+          kind: Deployment
+          name: helm-controller
+        patch: |
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --concurrent=30


### PR DESCRIPTION
Move the ClusterSecretStore to the GitOps repo, since External-Secrets won't exist at startup and will cause a circular dependency 